### PR TITLE
Sample(EJ2-64938): Lock rejected stamp

### DIFF
--- a/How to/Lock rejected stamp/index.html
+++ b/How to/Lock rejected stamp/index.html
@@ -1,0 +1,75 @@
+<html>
+
+<head>
+    <!--Refer scripts and styles from CDN-->
+    <script src="https://cdn.syncfusion.com/ej2/20.2.48/dist/ej2.min.js" type="text/javascript">
+    </script>
+
+    <link href="https://cdn.syncfusion.com/ej2/20.2.48/material.css" rel="stylesheet" />
+
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" />
+
+    <style>
+        body {
+            touch-action: none;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="control-section">
+        <div class="content-wrapper">
+            <button id="lock">Lock rejected stamp</button>
+            <!--Add the PDF Viewer-->
+            <div id="pdfViewer" style="height: 640px; width: 100%"></div>
+        </div>
+    </div>
+    <script>
+        var viewer = new ej.pdfviewer.PdfViewer({
+            //Sets the document path for initial loading.
+            documentPath: 'PDF_Succinctly.pdf',
+            serviceUrl: 'https://ej2services.syncfusion.com/production/web-services/api/pdfviewer',
+        });
+        //Inject the dependencies required to render the PDF Viewer.
+        ej.pdfviewer.PdfViewer.Inject(
+            ej.pdfviewer.Toolbar,
+            ej.pdfviewer.Magnification,
+            ej.pdfviewer.BookmarkView,
+            ej.pdfviewer.ThumbnailView,
+            ej.pdfviewer.TextSelection,
+            ej.pdfviewer.TextSearch,
+            ej.pdfviewer.Print, 
+            ej.pdfviewer.Navigation,
+            ej.pdfviewer.LinkAnnotation,
+            ej.pdfviewer.Annotation,
+            ej.pdfviewer.FormFields,
+            ej.pdfviewer.FormDesigner
+        );
+        // Code to add stamps while loading
+        viewer.documentLoad = function (args) {
+            viewer.annotation.addAnnotation("Stamp", {
+                offset: {x: 200, y: 200}, 
+                pageNumber: 1
+            }, "Approved");
+            viewer.annotation.addAnnotation("Stamp", {
+                offset: {x: 200, y: 300}, 
+                pageNumber: 1
+            }, null, "Rejected");
+        }
+        viewer.appendTo('#pdfViewer');
+
+        document.getElementById("lock").addEventListener('click', function () {
+            var viewer = document.getElementById('pdfViewer').ej2_instances[0];
+            for (var i = 0; i < viewer.annotationCollection.length; i++) {
+                // Check whether it is rejected stamp or not
+                if ((viewer.annotationCollection[i].shapeAnnotationType === "stamp") && (viewer.annotationCollection[i].icon === "Rejected")) {             
+                    // Code to lock the rejected stamp
+                    viewer.annotationCollection[i].annotationSettings.isLock = true;
+                    viewer.annotation.editAnnotation(viewer.annotationCollection[i]);
+                }
+            }
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
### Sample description
* Need to add the details about injecting modules.

### Action taken:
* To lock the rejected stamp alone in Javascript

### Related areas:
* NA

### Is it a breaking issue?
No

### Output screenshots
NA

### Solution description
* I have added the folder to lock the rejected sample alone

### Areas affected and ensured
Manually tested these fixes It's working fine.


### Additional checklist
Is there any API name change? No
Is there any existing behavior change of other features due to this code change? No
Does your new code introduce new warnings or binding errors? No
Does your code pass all FxCop and StyleCop rules? No
