### PR TITLE
Sample(EJ2-64829): To hide the save signature option in the dialog box

### DIFF
--- a/How to/Hide save signarure/index.html
+++ b/How to/Hide save signarure/index.html
@@ -1,0 +1,61 @@
+<html>
+
+<head>
+    <!--Refer scripts and styles from CDN-->
+    <script src="https://cdn.syncfusion.com/ej2/20.2.48/dist/ej2.min.js" type="text/javascript">
+    </script>
+
+    <link href="https://cdn.syncfusion.com/ej2/20.2.48/material.css" rel="stylesheet" />
+
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" />
+
+    <style>
+        body {
+            touch-action: none;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="control-section">
+        <div class="content-wrapper">
+            <!--Add the PDF Viewer-->
+            <div id="pdfViewer" style="height: 640px; width: 100%"></div>
+        </div>
+    </div>
+    <script>
+        var viewer = new ej.pdfviewer.PdfViewer({
+            //Sets the document path for initial loading.
+            documentPath: 'PDF_Succinctly.pdf',
+            serviceUrl: 'https://ej2services.syncfusion.com/production/web-services/api/pdfviewer',
+        });
+        //Inject the dependencies required to render the PDF Viewer.
+        ej.pdfviewer.PdfViewer.Inject(
+            ej.pdfviewer.Toolbar,
+            ej.pdfviewer.Magnification,
+            ej.pdfviewer.BookmarkView,
+            ej.pdfviewer.ThumbnailView,
+            ej.pdfviewer.TextSelection,
+            ej.pdfviewer.TextSearch,
+            ej.pdfviewer.Print,
+            ej.pdfviewer.Navigation,
+            ej.pdfviewer.LinkAnnotation,
+            ej.pdfviewer.Annotation,
+            ej.pdfviewer.FormFields,
+            ej.pdfviewer.FormDesigner
+        );
+        // Code to hide save signature option
+        viewer.signatureFieldSettings.signatureDialogSettings.hideSaveSignature = true;
+        viewer.handWrittenSignatureSettings.signatureDialogSettings.hideSaveSignature = true;
+        viewer.initialFieldSettings.initialDialogSettings.hideSaveSignature = true;
+        viewer.handWrittenSignatureSettings.initialDialogSettings.hideSaveSignature = true;
+        // Code to add signature field while loading
+        viewer.documentLoad = function (args) {
+            viewer.formDesignerModule.addFormField("SignatureField", { name: "Sign", bounds: { X: 57, Y: 300, Width: 200, Height: 43 } });
+            viewer.formDesignerModule.addFormField("InitialField", { name: "Agree", bounds: { X: 148, Y: 400, Width: 200, Height: 43 } });
+        }
+        viewer.appendTo('#pdfViewer');
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
### Sample description
* To hide the save signature option in the dialog box

### Action taken:
* To hide the save signature option in the dialog box

### Related areas:
* NA

### Is it a breaking issue?
No

### Output screenshots
NA

### Solution description
* I have added the folder to hide the save signature option in the signature field

### Areas affected and ensured
I manually tested these fixes It's working fine.

### Additional checklist
Is there any API name change? No
Is there any existing behavior change of other features due to this code change? No
Does your new code introduce new warnings or binding errors? No
Does your code pass all FxCop and StyleCop rules? No
